### PR TITLE
refs #22 フッタの SNS アイコンを一旦非表示にした

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,22 @@
+{{ "<!-- footer -->" | safeHTML }}
+<footer class="section pb-4">
+  <div class="container">
+    <div class="row align-items-center">
+      <div class="col-md-8 text-md-left text-center">
+       <p class="mb-md-0 mb-4">{{ .Site.Params.copyright | markdownify }}</p>
+      </div>
+      <!-- <div class="col-md-4 text-md-right text-center">
+        <ul class="list-inline">
+          {{ range .Site.Params.social }}
+          <li class="list-inline-item"><a class="text-color d-inline-block p-2" href="{{ .link | safeURL }}" aria-label="{{ .name }}"><i class="{{ .icon }}"></i></a></li>
+          {{ end }}
+        </ul>
+      </div> -->
+    </div>
+  </div>
+</footer>
+{{ "<!-- /footer -->" | safeHTML }}
+
+{{ "<!-- Main Script -->" | safeHTML }}
+{{ $script := resources.Get "js/script.js" | minify}}
+<script src="{{ $script.Permalink }}"></script>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #22

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- フッタの SNS アイコンを非表示に

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1200" alt="スクリーンショット 2021-12-16 13 16 46" src="https://user-images.githubusercontent.com/35142774/146307687-d02751a9-a924-45fb-af9b-c97349f58dff.png">

- 8 〜 14 行目をコメントアウトしてあります。
- 画面幅が広い場合は↑のとおり Copyright 表記が左寄せになりますが、今後 GitHub アイコンを復活させる可能性もあるので、一旦このままにしておきます。