### PR TITLE
refs #21 ハンバーガーメニューのアイコン色を白に変更

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,0 +1,68 @@
+<nav class="navbar navbar-expand-md navbar-dark">
+  <div class="container px-2 px-md-0">
+    <a class="navbar-brand px-2" href="{{ site.BaseURL | relLangURL }}">
+      {{ $logo:= site.Params.logo }}
+      {{ $logoWhite:= site.Params.logo_white }}
+      {{ if (or $logo $logoWhite) }}
+      {{ if .IsHome }}
+      <img class="img-fluid" src="{{if $logoWhite }}{{ $logoWhite | absURL }} {{ else }} {{ $logo | absURL }}{{ end }}"
+        alt="{{ site.Title }}">
+      {{ else }}
+      <img class="img-fluid" src="{{ $logo | absURL }}" alt="{{ site.Title }}">
+      {{ end }}
+      {{ else }}
+      {{ site.Title }}
+      {{ end }}
+    </a>
+    <button class="navbar-toggler border-0" type="button" data-toggle="collapse" data-target="#navigation"
+      aria-controls="navigation" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse text-center" id="navigation">
+      <ul class="navbar-nav ml-auto">
+        {{ range site.Menus.main }}
+        {{ if .HasChildren }}
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle text-dark" href="#" role="button" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="false">
+            {{ .Name }}
+          </a>
+          <div class="dropdown-menu">
+            {{ range .Children }}
+            <a class="dropdown-item" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
+            {{ end }}
+          </div>
+        </li>
+        {{ else }}
+        <li class="nav-item">
+          <a class="nav-link text-dark" href="{{ .URL | absLangURL }}">{{ .Name }}</a>
+        </li>
+        {{ end }}
+        {{ end }}
+      </ul>
+      <!-- Language List -->
+      {{- if site.IsMultiLingual }}
+      <select class="lang-list {{ if not .IsHome }}dark mb-3 mb-md-0{{ end }}" id="select-language"
+        onchange="location = this.value;">
+        {{ $siteLanguages := site.Languages}}
+        {{ $pageLang := .Page.Lang}}
+        {{ range .Page.AllTranslations }}
+        {{ $translation := .}}
+        {{ range $siteLanguages }}
+        {{ if eq $translation.Lang .Lang }}
+        {{ $selected := false }}
+        {{ if eq $pageLang .Lang}}
+        <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}" selected>{{ .LanguageName }}
+        </option>
+        {{ else }}
+        <option id="{{ $translation.Language }}" value="{{ $translation.Permalink }}">{{ .LanguageName }}</option>
+        {{ end }}
+        {{ end }}
+        {{ end }}
+        {{ end }}
+      </select>
+      {{ end }}
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #21

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- カテゴリ別ページのハンバーガーメニューアイコン（画面幅が狭くなったときに表示される）の色を白に

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

![image](https://user-images.githubusercontent.com/35142774/146309299-5dfb15e2-5e03-430b-89f7-0a0d1316e23e.png)

- 変更は実質 1 行目だけです（トップ（Home）に合わせて`navbar-dark`に）。
- どのみち、「HOME」「FAQ」と言語選択を（一旦）消すのであればこのアイコンも（一旦は）不要になるのですが、言語選択や About ページのために復活させる可能性があるので、最低限の対処をしておきました。