### PR TITLE
refs #23 検索仮実装

### DIFF
--- a/content/search/_index.ja.md
+++ b/content/search/_index.ja.md
@@ -1,0 +1,36 @@
+---
+title: "検索"
+draft: false
+---
+<input id = "query" onkeyup="search(this.value)" size="30" autocomplete="off" autofocus placeholder="検索キーワードを入れてください" />
+
+<script>
+    // 検索
+    function search(query) {
+        $(".card").each(function(i, elem) {
+            var question = $(elem).find("span").text().toLowerCase();
+            var answer = $(elem).find(".card-body").text().toLowerCase();
+            if (query == "" || (question.indexOf(query) == -1 && answer.indexOf(query) == -1)) {
+                $(elem).css("display", "none");
+            } else {
+                $(elem).css("display", "block");
+            }
+        })
+    }
+    // ハッシュフラグメントの値で検索を実行
+    function searchWithHash() {
+        const hash = decodeURI(location.hash.substring(1));
+        search(hash);
+        // 必要があれば input 要素の値を更新
+        const queryElem = document.getElementById('query');
+        if (queryElem.value !== hash) {
+        queryElem.value = hash;
+        }
+    }
+    // ハッシュフラグメント付きの URL でページを開いたときに検索
+    window.addEventListener('DOMContentLoaded', searchWithHash);
+    // ページ表示後にハッシュフラグメントが変化したら検索
+    window.addEventListener('hashchange', searchWithHash);
+</script>
+
+{{< result >}}

--- a/content/search/_index.ja.md
+++ b/content/search/_index.ja.md
@@ -1,8 +1,8 @@
 ---
-title: "検索"
+title: "全てのカテゴリから検索"
 draft: false
 ---
-<input id = "query" onkeyup="search(this.value)" size="25" autocomplete="off" autofocus placeholder="キーワードを入れてください" />
+<input id = "query" onkeyup="search(this.value)" size="30" autocomplete="off" autofocus placeholder="検索キーワードを入れてください" />
 
 <script>
     // 検索

--- a/content/search/_index.ja.md
+++ b/content/search/_index.ja.md
@@ -2,7 +2,7 @@
 title: "全てのカテゴリから検索"
 draft: false
 ---
-<input id = "query" onkeyup="search(this.value)" size="30" autocomplete="off" autofocus placeholder="検索キーワードを入れてください" />
+<input id = "query" onkeyup="search(this.value)" size="28" autocomplete="off" autofocus placeholder="検索キーワードを入れてください" />
 
 <script>
     // 検索

--- a/content/search/_index.ja.md
+++ b/content/search/_index.ja.md
@@ -2,7 +2,7 @@
 title: "検索"
 draft: false
 ---
-<input id = "query" onkeyup="search(this.value)" size="30" autocomplete="off" autofocus placeholder="検索キーワードを入れてください" />
+<input id = "query" onkeyup="search(this.value)" size="25" autocomplete="off" autofocus placeholder="キーワードを入れてください" />
 
 <script>
     // 検索

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,5 +1,5 @@
 {{ "<!-- banner -->" | safeHTML }}
-<div class="container section">
+<div class="container section" style="padding-bottom: 24px;">
 	<div class="row">
 		<div class="col-lg-8 text-center mx-auto">
 			<h1 class="text-white mb-3">{{ .Site.Params.banner.title | markdownify }}</h1>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -8,11 +8,11 @@
 				<form>
 					<input id="searchKeyword" class="form-control" style="margin-top: 16px;" placeholder="検索キーワードを入れてください">
 					<i class="ti-search search-icon"></i>
-					<input id="searchButton" type="submit" value="" style="background-color: transparent; border: transparent;">
+					<input id="searchButton" type="submit" value="" style="color: transparent; background-color: transparent; border: transparent;">
 				</form>
 
 				<script>
-					const SEARCH_URL = '/vaccinecert-faq/search/';
+					const SEARCH_URL = '/search/';
 
 					window.addEventListener('DOMContentLoaded', () => {
 						const searchButton = document.getElementById('searchButton');

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -4,8 +4,29 @@
 		<div class="col-lg-8 text-center mx-auto">
 			<h1 class="text-white mb-3">{{ .Site.Params.banner.title | markdownify }}</h1>
 			<p class="text-white mb-4">{{ .Site.Params.banner.subtitle | markdownify }}</p>
-			<!-- <div class="position-relative">
-				<input id="search" class="form-control" placeholder="{{ .Site.Params.banner.placeholder }}">
+			<div class="position-relative">
+				<form>
+					<input id="searchKeyword" type="search" size="30" style="margin-top: 16px;">
+					<input id="searchButton" type="submit" value="検索">
+				</form>
+
+				<script>
+					const SEARCH_URL = '/vaccinecert-faq/search/';
+
+					window.addEventListener('DOMContentLoaded', () => {
+						const searchButton = document.getElementById('searchButton');
+						const searchKeyword = document.getElementById('searchKeyword');
+
+						// 検索ボタンのクリックで検索ページへジャンプ
+						searchButton.addEventListener('click', e => {
+							e.preventDefault();  // Prevent default form's behavior
+							const query = searchKeyword.value;
+							const url = query ? SEARCH_URL + '#' + query : SEARCH_URL;
+							location.href = url;
+						});
+					});
+				</script>
+				<!-- <input id="search" class="form-control" placeholder="{{ .Site.Params.banner.placeholder }}">
 				<i class="ti-search search-icon"></i> -->
 				<!-- Javascript -->
 				<!-- {{ $currentNode := . }}
@@ -31,8 +52,8 @@
 						.appendTo( ul );
 					};
 					});
-				</script>
-			</div> -->
+				</script> -->
+			</div>
 		</div>
 	</div>
 </div>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -6,8 +6,9 @@
 			<p class="text-white mb-4">{{ .Site.Params.banner.subtitle | markdownify }}</p>
 			<div class="position-relative">
 				<form>
-					<input id="searchKeyword" type="search" size="25" style="margin-top: 16px;">
-					<input id="searchButton" type="submit" value="検索">
+					<input id="searchKeyword" class="form-control" style="margin-top: 16px;" placeholder="検索キーワードを入れてください">
+					<i class="ti-search search-icon"></i>
+					<input id="searchButton" type="submit" value="" style="display: none;">
 				</form>
 
 				<script>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -8,7 +8,7 @@
 				<form>
 					<input id="searchKeyword" class="form-control" style="margin-top: 16px;" placeholder="検索キーワードを入れてください">
 					<i class="ti-search search-icon"></i>
-					<input id="searchButton" type="submit" value="" style="display: none;">
+					<input id="searchButton" type="submit" value="" style="background-color: transparent; border: transparent;">
 				</form>
 
 				<script>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -6,7 +6,7 @@
 			<p class="text-white mb-4">{{ .Site.Params.banner.subtitle | markdownify }}</p>
 			<div class="position-relative">
 				<form>
-					<input id="searchKeyword" type="search" size="30" style="margin-top: 16px;">
+					<input id="searchKeyword" type="search" size="25" style="margin-top: 16px;">
 					<input id="searchButton" type="submit" value="検索">
 				</form>
 

--- a/layouts/shortcodes/result.html
+++ b/layouts/shortcodes/result.html
@@ -1,0 +1,20 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ range $faq := (where $.Site.Data.faq.faq "カテゴリ名" "!=" "") }}
+<div class="card mb-4 rounded-0 shadow border-0" style="display: none;">
+  <div class="card-header rounded-0 bg-white border p-0 border-0">
+    <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse"
+      href="#{{ $faq.質問 | sha1 }}">
+      <span>{{ $faq.質問 }}</span> <i class="ti-plus text-primary text-right"></i>
+    </a>
+  </div>
+  <div id="{{ $faq.質問 | sha1 }}" class="collapse" data-parent="#accordion">
+    <div class="card-body font-secondary text-color pt-0" style="white-space:pre-wrap; margin-bottom: 0px;">{{ $faq.回答 }}</div>
+    <div class="card-footer rounded-0 bg-white border p-0 border-0" style="text-align: right; margin-bottom: 0px; margin-right: 20px;">
+      {{ if eq (len $faq.更新日) 8 }}
+        最終更新日：{{ slicestr $faq.更新日 0 4 }}年{{ slicestr $faq.更新日 4 6 | strings.TrimLeft "0" }}月{{ slicestr $faq.更新日 6 | strings.TrimLeft "0" }}日&nbsp;
+      {{ end}}
+    </div>
+  </div>
+  {{ .Inner }}
+</div>
+{{ end }}

--- a/layouts/shortcodes/result.html
+++ b/layouts/shortcodes/result.html
@@ -8,11 +8,13 @@
     </a>
   </div>
   <div id="{{ $faq.質問 | sha1 }}" class="collapse" data-parent="#accordion">
-    <div class="card-body font-secondary text-color pt-0" style="white-space:pre-wrap; margin-bottom: 0px;">{{ $faq.回答 }}</div>
+    <div class="card-body font-secondary text-color pt-0" style="white-space:pre-wrap; margin-bottom: 0px;">{{ $faq.回答 | markdownify }}</div>
     <div class="card-footer rounded-0 bg-white border p-0 border-0" style="text-align: right; margin-bottom: 0px; margin-right: 20px;">
       {{ if eq (len $faq.更新日) 8 }}
         最終更新日：{{ slicestr $faq.更新日 0 4 }}年{{ slicestr $faq.更新日 4 6 | strings.TrimLeft "0" }}月{{ slicestr $faq.更新日 6 | strings.TrimLeft "0" }}日&nbsp;
       {{ end}}
+      <br/>
+      <br/>
     </div>
   </div>
   {{ .Inner }}


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- #23 
  - 仮実装なので close しません

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 検索一覧画面に該当する Q&A をすべて一覧表示する（そこからカテゴリ別のページには遷移しないで、その場で対象の Q&A を表示する）形の検索を実装しました
- 検索窓およびハッシュフラグメント経由の検索は、こちらの実装を利用させていただきました（検索本体は自前）
  - https://maku77.github.io/hugo/advanced/full-text-search.html

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

- トップページ

![image](https://user-images.githubusercontent.com/35142774/146789552-a275241a-d6bf-423f-bb39-1e37eb11fd16.png)

- 検索結果（兼検索）ページ
  - 最初から A を展開しておく方法がわからず…（展開しても鬱陶しいだけかもしれない）

![image](https://user-images.githubusercontent.com/35142774/146789639-bf3a5f3a-3c51-48a2-abf5-efc6d7740ab7.png)

- 検索ページの下に前後の遷移が出てしまうのがイケてないですが…。

![image](https://user-images.githubusercontent.com/35142774/146792011-ad220f16-ad27-460d-8b17-a1e9adb884b5.png)
