### PR TITLE
検索ページを調整する（件数表示・ページネーション非表示）

### DIFF
--- a/content/search/_index.ja.md
+++ b/content/search/_index.ja.md
@@ -4,9 +4,14 @@ draft: false
 ---
 <input id = "query" onkeyup="location.replace('#' + this.value)" style="width: 90%;" autocomplete="off" autofocus placeholder="検索キーワードを入れてください" />
 
+<div id = "result">
+    <span id ="count">0</span> 件の質問・回答が見つかりました
+</div>
+
 <script>
     // 検索
     function search(query) {
+        var count = 0;
         $(".card").each(function(i, elem) {
             var question = $(elem).find("span").text().toLowerCase();
             var answer = $(elem).find(".card-body").text().toLowerCase();
@@ -14,8 +19,10 @@ draft: false
                 $(elem).css("display", "none");
             } else {
                 $(elem).css("display", "block");
+                count++;
             }
         })
+        $("#result #count").text(count);
     }
     // ハッシュフラグメントの値で検索を実行
     function searchWithHash() {

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -67,12 +67,14 @@
             {{ end }}
             {{ end }}
 
+            {{ if ne .Title "全てのカテゴリから検索" }}
             {{with ($.Scratch.Get "prevPage")}}
             <a class="nav nav-prev" href="{{.Permalink }}" aria-label="Previous page" ><i class="ti-arrow-left mr-2"></i> <span class="d-none d-md-block">{{.Title}}</span></a>
             {{end}}
             {{with ($.Scratch.Get "nextPage")}}
             <a class="nav nav-next" href="{{.Permalink }}" aria-label="Previous page" > <span class="d-none d-md-block">{{.Title}}</span><i class="ti-arrow-right ml-2"></i></a>
             {{end}}
+            {{ end }}
           </nav>
         </div>
       </div>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #75

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ↓の通り、検索ページにヒット数を表示し、ページネーションを（一部不十分なところはあるものの）非表示にしました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/35142774/147096871-8dbe4879-c9c9-4bc9-a11f-e7ee9c7d0490.png)

- なお、ページネーションについては実は対策が不十分で、ABOUT ページから検索ページへは遷移ができてしまいます（逆方向へは行けません）。許容範囲だと考えてそのままにしてあります。

![image](https://user-images.githubusercontent.com/35142774/147099506-f4120662-4fc7-4435-b0c1-1d2a5ddb8e94.png)

- ヒット数が 0 だった場合に文言を「該当する質問・回答はありませんでした」に変えようかとも考えたのですが、検索キーワードが空欄のときにその文言が表示されるのも不自然で、そうなると空欄時のパターンも用意することになり、煩雑なので一旦「0 件の質問・回答が見つかりました」のままにしてあります。