### PR TITLE
WIP: コンテンツ自動作成とURL再構成

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -62,6 +62,10 @@ link = "#"
 
 HasCJKLanguage = true
 
+[taxonomies]
+  tag = "tags"
+  category = "categories"
+
 [languages]
   ################################ Japanese Language ######################
   [Languages.ja]

--- a/content/faq1/_index.ja.md
+++ b/content/faq1/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "1_接種証明書アプリについて"
-draft: false
-type : "docs"
-weight : 1
----
-
-{{< vaccinefaq category="1_接種証明書アプリについて" >}}

--- a/content/faq10/_index.ja.md
+++ b/content/faq10/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "10_その他"
-draft: false
-type : "docs"
-weight : 10
----
-
-{{< vaccinefaq category="10_その他" >}}

--- a/content/faq2/_index.ja.md
+++ b/content/faq2/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "2_アプリでの接種証明書の発行について"
-draft: false
-type : "docs"
-weight : 2
----
-
-{{< vaccinefaq category="2_アプリでの接種証明書の発行について" >}}

--- a/content/faq3/_index.ja.md
+++ b/content/faq3/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "3_このような場合は発行できますか"
-draft: false
-type : "docs"
-weight : 3
----
-
-{{< vaccinefaq category="3_このような場合は発行できますか" >}}

--- a/content/faq4/_index.ja.md
+++ b/content/faq4/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "4_どの市区町村を選んで発行すればよいですか"
-draft: false
-type : "docs"
-weight : 4
----
-
-{{< vaccinefaq category="4_どの市区町村を選んで発行すればよいですか" >}}

--- a/content/faq5/_index.ja.md
+++ b/content/faq5/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "5_アプリでうまく発行できません"
-draft: false
-type : "docs"
-weight : 5
----
-
-{{< vaccinefaq category="5_アプリでうまく発行できません" >}}

--- a/content/faq6/_index.ja.md
+++ b/content/faq6/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "6_接種証明書の記載内容について"
-draft: false
-type : "docs"
-weight : 6
----
-
-{{< vaccinefaq category="6_接種証明書の記載内容について" >}}

--- a/content/faq7/_index.ja.md
+++ b/content/faq7/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "7_接種証明書の利用について"
-draft: false
-type : "docs"
-weight : 7
----
-
-{{< vaccinefaq category="7_接種証明書の利用について" >}}

--- a/content/faq8/_index.ja.md
+++ b/content/faq8/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "8_接種証明書の読み取りについて"
-draft: false
-type : "docs"
-weight : 8
----
-
-{{< vaccinefaq category="8_接種証明書の読み取りについて" >}}

--- a/content/faq9/_index.ja.md
+++ b/content/faq9/_index.ja.md
@@ -1,8 +1,0 @@
----
-title: "9_アプリの機能について"
-draft: false
-type : "docs"
-weight : 9
----
-
-{{< vaccinefaq category="9_アプリの機能について" >}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,53 @@
+{{ define "main" }}
+
+  {{ if .Content }}
+  <section class="section text-center">
+    <div class="container-fluid">
+    {{ .Content }}
+    </div>
+  </section>
+  {{ end }}
+  {{ "<!-- topics -->" | safeHTML }}
+  <section class="section">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-12 text-center">
+          <h2 class="section-title">{{ i18n "topics_title" | safeHTML }}</h2>
+        </div>
+        {{ "<!-- topic-item -->" | safeHTML }}
+        {{ range .Site.Taxonomies.categories.Alphabetical }}
+        <div class="col-lg-4 col-sm-6 mb-4">
+          <a href="{{ "/categories/" | relURL }}{{ .Name | urlize }}"  class="px-4 py-5 bg-white shadow text-center d-block match-height">
+            <h3 class="mb-3 mt-0">{{ .Name }}</h3></a>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+  {{ "<!-- /topics -->" | safeHTML }}
+
+  {{ if .Site.Params.cta.enable }}
+  {{ with .Site.Params.cta }}
+  {{ "<!-- call to action -->" | safeHTML }}
+  <section>
+    <div class="container">
+      <div class="row">
+        <div class="col-12">
+          <div class="section px-3 bg-white shadow text-center">
+          <h2 class="mb-4">{{ .title | markdownify }}</h2>
+          <p class="mb-4">{{ .content | markdownify }}</p>
+          {{ if .button.enable }}
+          {{ with .button }}
+          <a href="{{ .link | relLangURL }}" class="btn btn-primary">{{ .label }}</a>
+          {{ end }}
+          {{ end }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  {{ "<!-- /call to action -->" | safeHTML }}
+  {{ end }}
+  {{ end }}
+
+{{ end }}

--- a/layouts/partials/default.html
+++ b/layouts/partials/default.html
@@ -23,8 +23,10 @@
         </div>
       </div> -->
       <div class="col-lg-12">
-        <div class="p-lg-5 p-4 bg-white" id="content">
-          <h2 class="mb-5" id="title">{{ .Title }}</h2>
+        <a href="{{ "/categories/" | relURL }}{{ .Params.categories | urlize }}"  class="px-4 py-5 bg-white shadow d-block match-height">
+          <h5 class="mb-3 mt-0">{{ .Params.categories }}</h5></a>
+        <div class="p-4 bg-white" id="content">
+          <h3 class="mb-5" id="title">{{ .Title }}</h3>
           {{ if .Content }}
           <div class="content">{{.Content}}</div>
           {{ else }}
@@ -34,7 +36,7 @@
             </ul>
           </div>
           {{ end }}
-          <p class="post-meta border-bottom pb-3 mb-0 mt-3">{{ if .Params.Lastmod }}Updated on {{ .Lastmod.Format "02 Jan 2006" }}{{ end }}</p>
+          <p class="post-meta border-bottom pb-3 mb-0 mt-3">{{ if .Params.Lastmod }}更新日 {{ .Lastmod.Format "2006-01-02" }}{{ end }}</p>
           <nav class="pagination mt-3">
             <!-- Next prev page -->
             {{ $currentNode := . }}
@@ -69,10 +71,10 @@
 
             {{ if ne .Title "全てのカテゴリから検索" }}
             {{with ($.Scratch.Get "prevPage")}}
-            <a class="nav nav-prev" href="{{.Permalink }}" aria-label="Previous page" ><i class="ti-arrow-left mr-2"></i> <span class="d-none d-md-block">{{.Title}}</span></a>
+            <a class="nav nav-prev" href="{{.Permalink }}" aria-label="Previous page" ><i class="ti-arrow-left mr-2"></i> <span class="d-none d-md-block">{{.Params.question_no}}</span></a>
             {{end}}
             {{with ($.Scratch.Get "nextPage")}}
-            <a class="nav nav-next" href="{{.Permalink }}" aria-label="Previous page" > <span class="d-none d-md-block">{{.Title}}</span><i class="ti-arrow-right ml-2"></i></a>
+            <a class="nav nav-next" href="{{.Permalink }}" aria-label="Previous page" > <span class="d-none d-md-block">{{.Params.question_no}}</span><i class="ti-arrow-right ml-2"></i></a>
             {{end}}
             {{ end }}
           </nav>
@@ -93,9 +95,8 @@
 {{ with .File }}{{ $fileUniqueID = .UniqueID }}{{ end }}
 {{ $currentNodeFileUniqueID := "" }}
 {{ with $currentNode.File }}{{ $currentNodeFileUniqueID = .UniqueID }}{{ end }}
-<li data-nav-id="{{.Permalink}}" title="{{.Title}}" class="sidelist
-  {{if eq $fileUniqueID $currentNodeFileUniqueID}}active{{end}}">
-  <a href="{{.Permalink}}">
+<li data-nav-id="{{.Permalink}}" title="{{.Title}}" class="sidelist {{if eq $fileUniqueID $currentNodeFileUniqueID}}active{{end}}">
+  <a href="{{.Permalink}}" class="text-dark mb-0 py-3 px-4 justify-content-between" style="font-size: 20px;">
     {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
   </a>
   {{ $numberOfPages := (add (len .Pages) (len .Sections)) }}

--- a/layouts/shortcodes/vaccinefaq.html
+++ b/layouts/shortcodes/vaccinefaq.html
@@ -1,20 +1,8 @@
 {{ $_hugo_config := `{ "version": 1 }` }}
-{{ range $faq := (where $.Site.Data.faq.faq "カテゴリ名" (.Get "category")) }}
 <div class="card mb-4 rounded-0 shadow border-0">
-  <div class="card-header rounded-0 bg-white border p-0 border-0">
-    <a class="card-link h4 d-flex tex-dark mb-0 py-3 px-4 justify-content-between" data-toggle="collapse"
-      href="#{{ $faq.質問 | sha1 }}">
-      <span>{{ $faq.質問 }}</span> <i class="ti-plus text-primary text-right"></i>
-    </a>
-  </div>
-  <div id="{{ $faq.質問 | sha1 }}" class="collapse" data-parent="#accordion">
-    <div class="card-body font-secondary text-color pt-0" style="white-space:pre-wrap; margin-bottom: 0px;">{{ $faq.回答 | markdownify }}</div>
+  <div>
+    <div class="card-body font-secondary text-color pt-0" style="white-space:pre-wrap; margin-bottom: 0px;">{{ .Inner| markdownify }}</div>
     <div class="card-footer rounded-0 bg-white border p-0 border-0" style="text-align: right; margin-bottom: 0px; margin-right: 20px;">
-      {{ if eq (len $faq.更新日) 8 }}
-        最終更新日：{{ slicestr $faq.更新日 0 4 }}年{{ slicestr $faq.更新日 4 6 | strings.TrimLeft "0" }}月{{ slicestr $faq.更新日 6 | strings.TrimLeft "0" }}日&nbsp;
-      {{ end}}
     </div>
   </div>
-  {{ .Inner }}
 </div>
-{{ end }}

--- a/tool/create-contents/main.py
+++ b/tool/create-contents/main.py
@@ -1,0 +1,68 @@
+# coding:utf-8
+import json
+import string
+import hashlib
+import os
+import glob
+import datetime
+
+with open('./data/faq/faq.json', 'rb') as fin:
+    faqs = json.load(fin)  # ファイルオブジェクトをオブジェクトに変換
+
+
+template = '''
+---
+title: ${question}
+question_no: ${question_no}
+draft: false
+weight: ${weight}
+categories: ${category}
+lastmod: ${lastmod}
+---
+
+{{< vaccinefaq>}}
+${answer}
+{{</ vaccinefaq>}}
+'''
+
+
+def create_contents(content, template):
+    category = content['カテゴリ名']
+    [category_no, category_name] = category.split('_', 2)
+    category = "{:02d}".format(int(category_no)) + '_' + category_name
+
+    question_no = f"Q{category_no}-{content['カテゴリ内No']}"
+    question = f"{question_no} {content['質問']}"
+    answer = content['回答']
+    lastmod = datetime.datetime.strptime(
+        content['更新日'], '%Y%m%d').strftime('%Y-%m-%d')
+    weight = int(category_no)*100 + int(content['カテゴリ内No'])
+
+    template_text = string.Template(template)
+    result = template_text.safe_substitute(
+        {'weight': weight, 'question_no': question_no, 'category': category, 'question': question, 'answer': answer, 'lastmod': lastmod})
+    return result
+
+
+contents = glob.glob('./content/faq/*.md')
+
+for content_file in contents:
+    try:
+        os.remove(content_file)
+    except OSError as e:
+        print(f"Error:{ e.strerror}")
+
+for faq in faqs:
+    category = faq['カテゴリ名']
+    [category_no, category_name] = category.split('_', 2)
+    sub_no = faq['カテゴリ内No']
+    question_no = f"Q{category_no}-{sub_no}"
+    no = faq['No']
+
+    title = faq['質問']
+    file_hash = hashlib.md5(title.encode()).hexdigest()
+    dirpath = './content/faq'
+    filename = no + '.ja.md'
+    filepath = os.path.join(dirpath, filename)
+    with open(filepath, mode='w', encoding='UTF-8') as f:
+        f.write(create_contents(faq, template))


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #9

## 📝 関連する issue / Related Issues
- #68 
- #81 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- JSONからQ&Aページコンテンツを自動作成する
- Q&A毎にURLができパーマリンクとして使うことができる

## 未対応事項
- 検索ページと検索ができていない

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

カテゴリページ
![image](https://user-images.githubusercontent.com/1209580/147380345-6f42509a-4e21-4992-a115-0af02e3d6e3d.png)

Q&Aページ
![image](https://user-images.githubusercontent.com/1209580/147380363-4110d5e2-061a-4bbb-be14-16d418f84a98.png)
